### PR TITLE
Remove Naver from disposable email list

### DIFF
--- a/disposable_email_blacklist.conf
+++ b/disposable_email_blacklist.conf
@@ -1306,7 +1306,6 @@ nabuma.com
 nakedtruth.biz
 nanonym.ch
 nationalgardeningclub.com
-naver.com
 negated.com
 neomailbox.com
 nepwk.com


### PR DESCRIPTION
Naver email domain seems to be frequently used in South Korea, and not as a disposable email provider.