### PR TITLE
Remove sibmail.com from disposable email list.

### DIFF
--- a/disposable_email_blacklist.conf
+++ b/disposable_email_blacklist.conf
@@ -1604,7 +1604,6 @@ showslow.de
 shrib.com
 shut.name
 shut.ws
-sibmail.com
 sify.com
 siliwangi.ga
 simpleitsecurity.info


### PR DESCRIPTION
It is a real email service, not a disposable one.
Belongs to Tomtel Internet-provider in Tomsk, Russia.
http://www.tomtel.ru/adds.html