### PR TITLE
Blacklist domains from trashmail.com

### DIFF
--- a/disposable_email_blacklist.conf
+++ b/disposable_email_blacklist.conf
@@ -4,6 +4,7 @@
 0815.ry
 0815.su
 0845.ru
+0box.eu
 0clickemail.com
 0wnd.net
 0wnd.org
@@ -350,6 +351,7 @@ compareshippingrates.org
 completegolfswing.com
 comwest.de
 consumerriot.com
+contbay.com
 coolandwacky.us
 coolimpool.org
 correo.blogos.net
@@ -377,6 +379,7 @@ dacoolest.com
 daemsteam.com
 daintly.com
 dammexe.net
+damnthespam.com
 dandikmail.com
 darkharvestfilms.com
 daryxfox.net


### PR DESCRIPTION
This pull request adds more domains used by [trashmail.com](https://trashmail.com/?cmd=features).