### PR TITLE
Removed pp.ua domain as it's an ukrainian regristar for private domain

### DIFF
--- a/disposable_email_blacklist.conf
+++ b/disposable_email_blacklist.conf
@@ -112,6 +112,7 @@ abyssmail.com
 ac20mail.in
 academiccommunity.com
 acentri.com
+add3000.pp.ua
 adiq.eu
 adobeccepdm.com
 adpugh.org
@@ -188,6 +189,7 @@ aschenbrandt.net
 asdasd.nl
 asdasd.ru
 ashleyandrew.com
+ass.pp.ua
 astroempires.info
 asu.mx
 asu.su
@@ -749,6 +751,7 @@ get-mail.cf
 get-mail.ga
 get-mail.ml
 get-mail.tk
+get.pp.ua
 get1mail.com
 get2mail.fr
 getairmail.cf
@@ -950,7 +953,9 @@ internetoftags.com
 interstats.org
 intersteller.com
 iozak.com
+ip4.pp.ua
 ip6.li
+ip6.pp.ua
 ipoo.org
 ipsur.org
 irc.so
@@ -1078,6 +1083,7 @@ login-email.ga
 login-email.ml
 login-email.tk
 logular.com
+loh.pp.ua
 loin.in
 lolfreak.net
 lolmail.biz
@@ -1267,6 +1273,7 @@ moreawesomethanyou.com
 moreorcs.com
 motique.de
 mountainregionallibrary.net
+mox.pp.ua
 moza.pl
 mr24.co
 msgos.com
@@ -1470,7 +1477,6 @@ postonline.me
 poutineyourface.com
 powered.name
 powlearn.com
-pp.ua
 primabananen.net
 privacy.net
 privatdemail.net
@@ -1758,6 +1764,7 @@ stop-my-spam.cf
 stop-my-spam.com
 stop-my-spam.ga
 stop-my-spam.ml
+stop-my-spam.pp.ua
 stop-my-spam.tk
 streetwisemail.com
 stromox.com
@@ -2134,6 +2141,7 @@ yopmail.com
 yopmail.fr
 yopmail.gq
 yopmail.net
+yopmail.pp.ua
 you-spam.com
 yougotgoated.com
 youmail.ga

--- a/disposable_email_blacklist.conf
+++ b/disposable_email_blacklist.conf
@@ -1332,7 +1332,6 @@ neomailbox.com
 nepwk.com
 nervmich.net
 nervtmich.net
-net.ua
 netmails.com
 netmails.net
 netricity.nl
@@ -1425,7 +1424,6 @@ oopi.org
 opayq.com
 opp24.com
 ordinaryamerican.net
-org.ua
 oroki.de
 oshietechan.link
 otherinbox.com
@@ -2179,7 +2177,6 @@ zoemail.org
 zoetropes.org
 zombie-hive.com
 zomg.info
-zp.ua
 zumpul.com
 zxcv.com
 zxcvbnm.com


### PR DESCRIPTION
See http://drs.ua/ and http://pp.ua/
See also the wikipedia article https://en.wikipedia.org/wiki/.ua

I also reintroduced `add3000.pp.ua`, `ass.pp.ua`, `get.pp.ua`, `ip4.pp.ua`, `ip6.pp.ua`, `loh.pp.ua`, `mox.pp.ua`, `stop-my-spam.pp.ua`, `yopmail.pp.ua` domains

There're already some subdomains entries for `pp.ua` in the `blacklist`file:
- `web-mail.pp.ua`
- `eml.pp.ua`
- `fake-email.pp.ua`
- `jetable.pp.ua`

See https://email-fake.com/mox.pp.ua/tarjeixsi for the list of all `pp.ua` fake domains.