### PR TITLE
NUS email removal

### DIFF
--- a/disposable_email_blacklist.conf
+++ b/disposable_email_blacklist.conf
@@ -1852,7 +1852,6 @@ ntlhelp.net
 nubescontrol.com
 nullbox.info
 nurfuerspam.de
-nus.edu.sg
 nut-cc.nut.cc
 nutcc.nut.cc
 nutpa.net

--- a/whitelist.conf
+++ b/whitelist.conf
@@ -122,6 +122,7 @@ naver.com
 neverbox.com
 nigge.rs
 nospammail.net
+nus.edu.sg
 onet.pl
 ownmail.net
 petml.com


### PR DESCRIPTION
The National University of Singapore should be in the whitelist.

http://nus.edu.sg
