### PR TITLE
Remove sohu.com

### DIFF
--- a/disposable_email_blacklist.conf
+++ b/disposable_email_blacklist.conf
@@ -2215,7 +2215,6 @@ sofortmail.de
 softpls.asia
 sogetthis.com
 sohai.ml
-sohu.com
 sohus.cn
 soioa.com
 soisz.com


### PR DESCRIPTION
> This seems like a "free email provider" (albeit in chinese) rather than a "disposable email provider".

See https://github.com/ivolo/disposable-email-domains/pull/282