### PR TITLE
add emaildrop.io to blocklist

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -800,6 +800,7 @@ emailage.gq
 emailage.ml
 emailage.tk
 emaildienst.de
+emaildrop.io
 emailfake.ml
 emailfake.nut.cc
 emailfreedom.ml


### PR DESCRIPTION
fixes https://github.com/martenson/disposable-email-domains/issues/189