### PR TITLE
add emailbin.org

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -799,6 +799,7 @@ emailage.ga
 emailage.gq
 emailage.ml
 emailage.tk
+emailbin.org
 emaildienst.de
 emaildrop.io
 emailfake.ml


### PR DESCRIPTION
http://emailbin.org/

From HackerNews forum
```
emailbin.org is running on elasticsearch with a hideous frontend of pure raw html hahaha
usecases:
* email signups
* posting of email threads to government
* your ideas
it is and will always be a free place to lay your emails to rest :-) 
source code https://github.com/emailbin/web
```
