### PR TITLE
Add new domains

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -833,6 +833,7 @@ email-lab.com
 email-temp.com
 email.cbes.net
 email.net
+email1.pro
 email60.com
 emailage.cf
 emailage.ga
@@ -1352,6 +1353,7 @@ iheartspam.org
 ikbenspamvrij.nl
 illistnoise.com
 ilovespam.com
+imail1.net
 imails.info
 imailt.com
 imgof.com
@@ -1652,6 +1654,7 @@ maidlow.info
 mail-card.net
 mail-easy.fr
 mail-filter.com
+mail-help.net
 mail-hub.info
 mail-now.top
 mail-owl.com
@@ -1663,8 +1666,10 @@ mail.by
 mail.mezimages.net
 mail.wtf
 mail0.ga
+mail1.top
 mail114.net
 mail1a.de
+mail1web.org
 mail21.cc
 mail22.club
 mail2rss.org
@@ -1718,6 +1723,7 @@ mailgutter.com
 mailhazard.com
 mailhazard.us
 mailhex.com
+mailhub.pro
 mailhz.me
 mailimate.com
 mailin8r.com
@@ -1821,6 +1827,7 @@ maswae.world
 matamuasu.ga
 matchpol.net
 matra.site
+max-mail.org
 mbx.cc
 mcache.net
 mciek.com
@@ -2595,6 +2602,7 @@ svk.jp
 svxr.org
 sweetpotato.ml
 sweetxxx.de
+swift-mail.net
 swift10minutemail.com
 sylvannet.com
 symphonyresume.com

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1353,6 +1353,7 @@ ikbenspamvrij.nl
 illistnoise.com
 ilovespam.com
 imails.info
+imailt.com
 imgof.com
 imgv.de
 immo-gerance.info
@@ -1652,6 +1653,7 @@ mail-card.net
 mail-easy.fr
 mail-filter.com
 mail-hub.info
+mail-now.top
 mail-owl.com
 mail-share.com
 mail-temporaire.com
@@ -1671,6 +1673,7 @@ mail4trash.com
 mail666.ru
 mail707.com
 mail72.com
+mailapp.top
 mailback.com
 mailbidon.com
 mailbiz.biz
@@ -1782,6 +1785,8 @@ mailsiphon.com
 mailslapping.com
 mailslite.com
 mailsucker.net
+mailt.net
+mailt.top
 mailtechx.com
 mailtemp.info
 mailtemporaire.com
@@ -1985,6 +1990,7 @@ nevermail.de
 newbpotato.tk
 newfilm24.ru
 newideasfornewpeople.info
+newmail.top
 next.ovh
 nextmail.info
 nextstopvalhalla.com
@@ -2076,6 +2082,7 @@ olimp-case.ru
 olypmall.ru
 omail.pro
 omnievents.org
+one-mail.top
 one-time.email
 one2mail.info
 oneoffemail.com
@@ -2199,6 +2206,7 @@ pro-tag.org
 procrackers.com
 profast.top
 projectcl.com
+promailt.com
 proprietativalcea.ro
 propscore.com
 protempmail.com
@@ -2733,6 +2741,8 @@ top101.de
 top1mail.ru
 top1post.ru
 topinrock.cf
+topmail2.com
+topmail2.net
 topofertasdehoy.com
 topranklist.de
 toprumours.com

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -281,7 +281,6 @@ ama-trans.de
 amadeuswe.us
 amail.club
 amail.com
-amail1.com
 amail4.me
 amazon-aws.org
 amberwe.us
@@ -834,7 +833,6 @@ email-lab.com
 email-temp.com
 email.cbes.net
 email.net
-email1.pro
 email60.com
 emailage.cf
 emailage.ga
@@ -1355,7 +1353,6 @@ iiron.us
 ikbenspamvrij.nl
 illistnoise.com
 ilovespam.com
-imail1.net
 imails.info
 imailt.com
 imgof.com
@@ -1656,7 +1653,6 @@ maidlow.info
 mail-card.net
 mail-easy.fr
 mail-filter.com
-mail-help.net
 mail-hub.info
 mail-now.top
 mail-owl.com
@@ -1668,10 +1664,8 @@ mail.by
 mail.mezimages.net
 mail.wtf
 mail0.ga
-mail1.top
 mail114.net
 mail1a.de
-mail1web.org
 mail21.cc
 mail22.club
 mail2rss.org
@@ -1725,7 +1719,6 @@ mailgutter.com
 mailhazard.com
 mailhazard.us
 mailhex.com
-mailhub.pro
 mailhz.me
 mailimate.com
 mailin8r.com
@@ -1829,7 +1822,6 @@ maswae.world
 matamuasu.ga
 matchpol.net
 matra.site
-max-mail.org
 mbx.cc
 mcache.net
 mciek.com
@@ -2604,7 +2596,6 @@ svk.jp
 svxr.org
 sweetpotato.ml
 sweetxxx.de
-swift-mail.net
 swift10minutemail.com
 sylvannet.com
 symphonyresume.com

--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -281,6 +281,7 @@ ama-trans.de
 amadeuswe.us
 amail.club
 amail.com
+amail1.com
 amail4.me
 amazon-aws.org
 amberwe.us
@@ -1350,6 +1351,7 @@ ignoremail.com
 ihateyoualot.info
 ihazspam.ca
 iheartspam.org
+iiron.us
 ikbenspamvrij.nl
 illistnoise.com
 ilovespam.com


### PR DESCRIPTION
Numerous spam registrations were noticed on our service with emails on the following domains:
```
newmail.top
imailt.com
topmail2.net
topmail2.com
mail-now.top
one-mail.top
mailt.net
mailt.top
promailt.com
mailapp.top
```