### PR TITLE
Update disposable_email_blocklist.conf

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1268,6 +1268,7 @@ helpjobs.ru
 heros3.com
 herp.in
 herpderp.nl
+hey.com
 hezll.com
 hi5.si
 hiddentragedy.com


### PR DESCRIPTION
add hey.com
![DA0E22A7-460A-432A-8D9D-12AA53F8577B](https://user-images.githubusercontent.com/67554573/85953789-20bf3180-b973-11ea-8f6a-e3d576c85148.png)

The [iOS app](https://apps.apple.com/gb/app/hey-email/id1506603805) allows you to create free disposable email addresses. 