### PR TITLE
Suggests Removeing 33Mail

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -90,7 +90,6 @@
 30minutemail.com
 30wave.com
 3202.com
-33mail.com
 36ru.com
 3d-painting.com
 3l6.com


### PR DESCRIPTION
Hiya, this is an awesome project!

I noticed that [33Mail](https://www.33mail.com/about) was on the `email_blocklist.conf`, but this service is not a temporary mail provider, and requires users to create an account, with valid contact details, and payment details (for premium plan). 

Since it's a privacy service, not a disposable email address, I'm making the suggestion that it probably doesn't need to be on this list? especially since there are no other forwarding mail providers included here

---

**Bit of Background**
Email alias forwarding services work by allowing users to use a different email alias for each online service (e.g. `facebook@john.33mail.com`, `github@my-domain.com`, `heroku@john.anonaddy.com`, etc). It enables users to protect their real email address, when creating online accounts, while still permanently receiving all email communication in their primary inbox. 33Mail works in exactly the same was as [other mail forwarding services](https://github.com/Lissy93/personal-security-checklist/blob/master/5_Privacy_Respecting_Software.md#anonymous-mail-forwarding) (like AnonAddy, SimpleLogin, ProtonMail aliases, and Firefox Private relay), and it's one of the most long standing of them all (running since 2008!)