### PR TITLE
Added disposable domains from simplelogin.io

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -237,6 +237,7 @@ akgq701.com
 al-qaeda.us
 albionwe.us
 alchemywe.us
+aleeas.com
 aliaswe.us
 alienware13.com
 aligamel.com
@@ -2382,6 +2383,8 @@ siliwangi.ga
 silvercoin.life
 sim-simka.ru
 simpleitsecurity.info
+simplelogin.co
+simplelogin.fr
 sin.cl
 sinema.ml
 sinfiltro.cl
@@ -2400,6 +2403,7 @@ slaskpost.se
 slave-auctions.net
 slippery.email
 slipry.net
+slmail.me
 slopsbox.com
 slothmail.net
 slushmail.com


### PR DESCRIPTION
Domains are available from https://simplelogin.io/
I was attacked by a spammer using their service.