### PR TITLE
Fix sort order

### DIFF
--- a/disposable_email_blocklist.conf
+++ b/disposable_email_blocklist.conf
@@ -1489,8 +1489,8 @@ kadokawa.ga
 kadokawa.gq
 kadokawa.ml
 kadokawa.tk
-kagi.be
 kaengu.ru
+kagi.be
 kakadua.net
 kalapi.org
 kamen-market.ru


### PR DESCRIPTION
Looks like https://github.com/martenson/disposable-email-domains/pull/246 was merged w/ failing CI.